### PR TITLE
Add review protocol handling and AI coding suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A cutting-edge e-discovery platform leveraging AI to transform document analysis
 - **AI-Powered Analysis**: Automatic summarization, PII detection, and entity extraction
 - **Document Viewer**: Review documents with advanced redaction capabilities
 - **Tagging System**: Organize documents with custom tags and categories
+- **Protocol-Driven Coding**: Upload review protocols to guide AI tagging
+- **Database Storage**: Persist documents and metadata in PostgreSQL
 - **Production Tools**: Generate production sets with Bates stamping
 
 ## Technology Stack

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -6,7 +6,8 @@ import {
   DocumentTag, InsertDocumentTag, documentTags,
   Redaction, InsertRedaction, redactions,
   ProductionSet, InsertProductionSet, productionSets,
-  ProductionDocument, InsertProductionDocument, productionDocuments
+  ProductionDocument, InsertProductionDocument, productionDocuments,
+  ReviewProtocol, InsertReviewProtocol, reviewProtocols
 } from '@shared/schema';
 import { eq, and, desc } from 'drizzle-orm';
 import { IStorage } from './storage';
@@ -191,5 +192,25 @@ export class DatabaseStorage implements IStorage {
       .values(insertProductionDocument)
       .returning();
     return productionDocument;
+  }
+
+  // Review Protocol operations
+  async getAllProtocols(): Promise<ReviewProtocol[]> {
+    return await db.select().from(reviewProtocols).orderBy(desc(reviewProtocols.uploadedAt));
+  }
+
+  async getProtocol(id: number): Promise<ReviewProtocol | undefined> {
+    const [protocol] = await db.select().from(reviewProtocols).where(eq(reviewProtocols.id, id));
+    return protocol || undefined;
+  }
+
+  async createProtocol(insertProtocol: InsertReviewProtocol): Promise<ReviewProtocol> {
+    const [protocol] = await db.insert(reviewProtocols).values(insertProtocol).returning();
+    return protocol;
+  }
+
+  async deleteProtocol(id: number): Promise<boolean> {
+    const [deleted] = await db.delete(reviewProtocols).where(eq(reviewProtocols.id, id)).returning();
+    return !!deleted;
   }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,12 +1,13 @@
 // Import necessary types
-import { 
-  User, InsertUser, 
-  Document, InsertDocument, 
-  Tag, InsertTag, 
-  DocumentTag, InsertDocumentTag, 
-  Redaction, InsertRedaction, 
-  ProductionSet, InsertProductionSet, 
-  ProductionDocument, InsertProductionDocument 
+import {
+  User, InsertUser,
+  Document, InsertDocument,
+  Tag, InsertTag,
+  DocumentTag, InsertDocumentTag,
+  Redaction, InsertRedaction,
+  ProductionSet, InsertProductionSet,
+  ProductionDocument, InsertProductionDocument,
+  ReviewProtocol, InsertReviewProtocol,
 } from '@shared/schema';
 
 // Define the storage interface
@@ -47,6 +48,12 @@ export interface IStorage {
   // Production Document operations
   getProductionDocuments(productionSetId: number): Promise<{ document: Document, batesNumber: string }[]>;
   addDocumentToProductionSet(productionDocument: InsertProductionDocument): Promise<ProductionDocument>;
+
+  // Review Protocol operations
+  getAllProtocols(): Promise<ReviewProtocol[]>;
+  getProtocol(id: number): Promise<ReviewProtocol | undefined>;
+  createProtocol(protocol: InsertReviewProtocol): Promise<ReviewProtocol>;
+  deleteProtocol(id: number): Promise<boolean>;
 }
 
 // Import our DatabaseStorage implementation

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -175,3 +175,19 @@ export const productionDocumentsRelations = relations(productionDocuments, ({ on
     references: [documents.id]
   })
 }));
+
+// ReviewProtocols table for protocol-driven coding
+export const reviewProtocols = pgTable("review_protocols", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  content: text("content").notNull(),
+  uploadedAt: timestamp("uploaded_at").defaultNow().notNull(),
+});
+
+export const insertReviewProtocolSchema = createInsertSchema(reviewProtocols).omit({
+  id: true,
+  uploadedAt: true,
+});
+
+export type InsertReviewProtocol = z.infer<typeof insertReviewProtocolSchema>;
+export type ReviewProtocol = typeof reviewProtocols.$inferSelect;


### PR DESCRIPTION
## Summary
- add `reviewProtocols` table to schema
- update storage interface and implementation
- expose CRUD API endpoints for review protocols
- extend AI service with protocol-based coding suggestions
- document new features in README

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*